### PR TITLE
Add logging when XRay is not available

### DIFF
--- a/packages/awssociate/lib/factory.ts
+++ b/packages/awssociate/lib/factory.ts
@@ -94,6 +94,7 @@ function decorateWithXRayIfAvailable<T>(service: T): T{
         return AWSXRay.captureAWSClient(service)
     }catch(err) {
         // XRay not available
+        console.log('AWS XRay SDK not available.  AWS SDK calls shall not be instrumented.')
         return service
     }
 }

--- a/packages/awssociate/lib/factory.ts
+++ b/packages/awssociate/lib/factory.ts
@@ -93,8 +93,7 @@ function decorateWithXRayIfAvailable<T>(service: T): T{
         const AWSXRay = require('aws-xray-sdk')
         return AWSXRay.captureAWSClient(service)
     }catch(err) {
-        // XRay not available
-        console.log('AWS XRay SDK not available.  AWS SDK calls shall not be instrumented.')
+        console.warn(`AWS XRay SDK not available.  AWS SDK calls shall not be instrumented.  Cause: '${err}'`)
         return service
     }
 }


### PR DESCRIPTION
At the moment, if AWS XRAY is not available, instrumentation shall fail silently.

This PR adds a warning indicating the underlying cause.
This will help users client issues instrumenting their functions with XRay